### PR TITLE
Property accessor is not available for certain ognl expressions.

### DIFF
--- a/src/main/java/net/sf/oval/Validator.java
+++ b/src/main/java/net/sf/oval/Validator.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package net.sf.oval;
 
-import static java.lang.Boolean.*;
+import static java.lang.Boolean.TRUE;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
@@ -115,12 +115,14 @@ public class Validator implements IValidator
 			return delegate;
 		}
 
-		public String[] getParameterNames(final Constructor< ? > constructor) throws ReflectionException
+		@Override
+        public String[] getParameterNames(final Constructor< ? > constructor) throws ReflectionException
 		{
 			return delegate.getParameterNames(constructor);
 		}
 
-		public String[] getParameterNames(final Method method) throws ReflectionException
+		@Override
+        public String[] getParameterNames(final Method method) throws ReflectionException
 		{
 			return delegate.getParameterNames(method);
 		}
@@ -854,7 +856,8 @@ public class Validator implements IValidator
 		}
 	}
 
-	public void assertValid(final Object validatedObject) throws IllegalArgumentException, ValidationFailedException,
+	@Override
+    public void assertValid(final Object validatedObject) throws IllegalArgumentException, ValidationFailedException,
 			ConstraintsViolatedException
 	{
 		final List<ConstraintViolation> violations = validate(validatedObject);
@@ -862,7 +865,8 @@ public class Validator implements IValidator
 		if (violations.size() > 0) throw translateException(new ConstraintsViolatedException(violations));
 	}
 
-	public void assertValidFieldValue(final Object validatedObject, final Field validatedField, final Object fieldValueToValidate)
+	@Override
+    public void assertValidFieldValue(final Object validatedObject, final Field validatedField, final Object fieldValueToValidate)
 			throws IllegalArgumentException, ValidationFailedException, ConstraintsViolatedException
 	{
 		final List<ConstraintViolation> violations = validateFieldValue(validatedObject, validatedField, fieldValueToValidate);
@@ -910,7 +914,7 @@ public class Validator implements IValidator
 					{
 						context = ContextCache.getFieldContext((Field) result.targetAccessor);
 					}
-					else
+					else if (result.targetAccessor != null)
 					{
 						context = ContextCache.getMethodReturnValueContext((Method) result.targetAccessor);
 					}
@@ -1499,7 +1503,8 @@ public class Validator implements IValidator
 		return ex;
 	}
 
-	public List<ConstraintViolation> validate(final Object validatedObject) throws IllegalArgumentException, ValidationFailedException
+	@Override
+    public List<ConstraintViolation> validate(final Object validatedObject) throws IllegalArgumentException, ValidationFailedException
 	{
 		Assert.argumentNotNull("validatedObject", validatedObject);
 
@@ -1521,7 +1526,8 @@ public class Validator implements IValidator
 		}
 	}
 
-	public List<ConstraintViolation> validate(final Object validatedObject, final String... profiles) throws IllegalArgumentException,
+	@Override
+    public List<ConstraintViolation> validate(final Object validatedObject, final String... profiles) throws IllegalArgumentException,
 			ValidationFailedException
 	{
 		Assert.argumentNotNull("validatedObject", validatedObject);
@@ -1544,7 +1550,8 @@ public class Validator implements IValidator
 		}
 	}
 
-	public List<ConstraintViolation> validateFieldValue(final Object validatedObject, final Field validatedField,
+	@Override
+    public List<ConstraintViolation> validateFieldValue(final Object validatedObject, final Field validatedField,
 			final Object fieldValueToValidate) throws IllegalArgumentException, ValidationFailedException
 	{
 		Assert.argumentNotNull("validatedObject", validatedObject);

--- a/src/main/java/net/sf/oval/Validator.java
+++ b/src/main/java/net/sf/oval/Validator.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package net.sf.oval;
 
-import static java.lang.Boolean.TRUE;
+import static java.lang.Boolean.*;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
@@ -115,14 +115,12 @@ public class Validator implements IValidator
 			return delegate;
 		}
 
-		@Override
-        public String[] getParameterNames(final Constructor< ? > constructor) throws ReflectionException
+		public String[] getParameterNames(final Constructor< ? > constructor) throws ReflectionException
 		{
 			return delegate.getParameterNames(constructor);
 		}
 
-		@Override
-        public String[] getParameterNames(final Method method) throws ReflectionException
+		public String[] getParameterNames(final Method method) throws ReflectionException
 		{
 			return delegate.getParameterNames(method);
 		}
@@ -856,8 +854,7 @@ public class Validator implements IValidator
 		}
 	}
 
-	@Override
-    public void assertValid(final Object validatedObject) throws IllegalArgumentException, ValidationFailedException,
+	public void assertValid(final Object validatedObject) throws IllegalArgumentException, ValidationFailedException,
 			ConstraintsViolatedException
 	{
 		final List<ConstraintViolation> violations = validate(validatedObject);
@@ -865,8 +862,7 @@ public class Validator implements IValidator
 		if (violations.size() > 0) throw translateException(new ConstraintsViolatedException(violations));
 	}
 
-	@Override
-    public void assertValidFieldValue(final Object validatedObject, final Field validatedField, final Object fieldValueToValidate)
+	public void assertValidFieldValue(final Object validatedObject, final Field validatedField, final Object fieldValueToValidate)
 			throws IllegalArgumentException, ValidationFailedException, ConstraintsViolatedException
 	{
 		final List<ConstraintViolation> violations = validateFieldValue(validatedObject, validatedField, fieldValueToValidate);
@@ -1503,8 +1499,7 @@ public class Validator implements IValidator
 		return ex;
 	}
 
-	@Override
-    public List<ConstraintViolation> validate(final Object validatedObject) throws IllegalArgumentException, ValidationFailedException
+	public List<ConstraintViolation> validate(final Object validatedObject) throws IllegalArgumentException, ValidationFailedException
 	{
 		Assert.argumentNotNull("validatedObject", validatedObject);
 
@@ -1526,8 +1521,7 @@ public class Validator implements IValidator
 		}
 	}
 
-	@Override
-    public List<ConstraintViolation> validate(final Object validatedObject, final String... profiles) throws IllegalArgumentException,
+	public List<ConstraintViolation> validate(final Object validatedObject, final String... profiles) throws IllegalArgumentException,
 			ValidationFailedException
 	{
 		Assert.argumentNotNull("validatedObject", validatedObject);
@@ -1550,8 +1544,7 @@ public class Validator implements IValidator
 		}
 	}
 
-	@Override
-    public List<ConstraintViolation> validateFieldValue(final Object validatedObject, final Field validatedField,
+	public List<ConstraintViolation> validateFieldValue(final Object validatedObject, final Field validatedField,
 			final Object fieldValueToValidate) throws IllegalArgumentException, ValidationFailedException
 	{
 		Assert.argumentNotNull("validatedObject", validatedObject);

--- a/src/test/java/net/sf/oval/test/validator/NoTargetAccessorTest.java
+++ b/src/test/java/net/sf/oval/test/validator/NoTargetAccessorTest.java
@@ -28,7 +28,7 @@ import net.sf.oval.constraint.AssertNull;
  */
 public class NoTargetAccessorTest
 {
-	
+
 	private Validator sut;
 	private HappyPopulation population;
 
@@ -36,8 +36,9 @@ public class NoTargetAccessorTest
 	 * Prepares validator and other stuff.
 	 */
 	@Before
-	public void pre() {
-		sut = new Validator();		
+	public void pre()
+	{
+		sut = new Validator();
 		population = new HappyPopulation();
 	}
 
@@ -45,11 +46,12 @@ public class NoTargetAccessorTest
 	 * Checks that all people of a happy population are happy
 	 */
 	@Test
-	public void okTest() {
+	public void okTest()
+	{
 		population.add(happy(), happy(), happy());
-		
+
 		List<ConstraintViolation> list = sut.validate(population);
-		
+
 		assertTrue("There must be not unhappy people in this population", list.isEmpty());
 	}
 
@@ -57,8 +59,9 @@ public class NoTargetAccessorTest
 	 * Checks that empty population is happy
 	 */
 	@Test
-	public void okTest_Empty() {
-		List<ConstraintViolation> list = sut.validate(population);		
+	public void okTest_Empty()
+	{
+		List<ConstraintViolation> list = sut.validate(population);
 		assertTrue("There must be not unhappy people in this population", list.isEmpty());
 	}
 
@@ -66,24 +69,27 @@ public class NoTargetAccessorTest
 	 * Checks that empty population is happy
 	 */
 	@Test
-	public void okTest_One() {
+	public void okTest_One()
+	{
 		population.add(happy());
-		
+
 		List<ConstraintViolation> list = sut.validate(population);
-		
+
 		assertTrue("There must be not unhappy people in this population", list.isEmpty());
 	}
 
 	/**
-	 * Checks that adding some unhappy people to the happy population will fail validation.
+	 * Checks that adding some unhappy people to the happy population will fail
+	 * validation.
 	 */
 	@Test
-	public void failTest_Some() {
+	public void failTest_Some()
+	{
 		population.add(happy(), unhappy(), unhappy(), happy());
-		
+
 		List<ConstraintViolation> list = sut.validate(population);
-		
-		assertFalse("This population should not be all happy",list.isEmpty());
+
+		assertFalse("This population should not be all happy", list.isEmpty());
 		assertEquals(1, list.size());
 		ConstraintViolation violation = list.get(0);
 		assertNull(violation.getCauses());
@@ -91,33 +97,35 @@ public class NoTargetAccessorTest
 	}
 
 	/**
-	 * Checks that adding some unhappy people to the happy population will fail validation.
+	 * Checks that adding some unhappy people to the happy population will fail
+	 * validation.
 	 */
 	@Test
-	public void failTest_All() {
+	public void failTest_All()
+	{
 		population.add(unhappy());
-		
+
 		List<ConstraintViolation> list = sut.validate(population);
-		
-		assertFalse("This population should not be all happy",list.isEmpty());
+
+		assertFalse("This population should not be all happy", list.isEmpty());
 		assertEquals(1, list.size());
 		ConstraintViolation violation = list.get(0);
 		assertNull(violation.getCauses());
 		assertEquals(population.people.get(0), violation.getInvalidValue());
 	}
 
-
 	/**
 	 * Sample population consisting of people.
+	 * 
 	 * @author anydoby
 	 *
 	 */
 	public static class HappyPopulation
 	{
-		
-		@AssertNull(target="jxpath:.[happy = false()]") 
+
+		@AssertNull(target = "jxpath:.[happy = false()]")
 		List<Person> people = new ArrayList<NoTargetAccessorTest.Person>();
-		
+
 		/**
 		 * @return happy people
 		 */
@@ -125,14 +133,15 @@ public class NoTargetAccessorTest
 		{
 			return people;
 		}
-		
+
 		/**
 		 * @param p
 		 */
-		public void add(Person... p) {
+		public void add(Person... p)
+		{
 			people.addAll(asList(p));
 		}
-		
+
 	}
 
 	/**
@@ -169,12 +178,12 @@ public class NoTargetAccessorTest
 			Person person = new Person();
 			return person;
 		}
-		
+
 		@Override
 		public String toString()
 		{
 			return isHappy() ? "happy" : "unhappy";
 		}
 	}
-	
+
 }

--- a/src/test/java/net/sf/oval/test/validator/NoTargetAccessorTest.java
+++ b/src/test/java/net/sf/oval/test/validator/NoTargetAccessorTest.java
@@ -1,0 +1,180 @@
+package net.sf.oval.test.validator;
+
+import static java.util.Arrays.asList;
+import static net.sf.oval.test.validator.NoTargetAccessorTest.Person.happy;
+import static net.sf.oval.test.validator.NoTargetAccessorTest.Person.unhappy;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import net.sf.oval.ConstraintViolation;
+import net.sf.oval.Validator;
+import net.sf.oval.constraint.AssertNull;
+
+/**
+ * This test checks that filtering a collection with a predicate (expressed with
+ * jxpath for example) and then checking the result works without exceptions.
+ * 
+ * @author anydoby
+ *
+ */
+public class NoTargetAccessorTest
+{
+	
+	private Validator sut;
+	private HappyPopulation population;
+
+	/**
+	 * Prepares validator and other stuff.
+	 */
+	@Before
+	public void pre() {
+		sut = new Validator();		
+		population = new HappyPopulation();
+	}
+
+	/**
+	 * Checks that all people of a happy population are happy
+	 */
+	@Test
+	public void okTest() {
+		population.add(happy(), happy(), happy());
+		
+		List<ConstraintViolation> list = sut.validate(population);
+		
+		assertTrue("There must be not unhappy people in this population", list.isEmpty());
+	}
+
+	/**
+	 * Checks that empty population is happy
+	 */
+	@Test
+	public void okTest_Empty() {
+		List<ConstraintViolation> list = sut.validate(population);		
+		assertTrue("There must be not unhappy people in this population", list.isEmpty());
+	}
+
+	/**
+	 * Checks that empty population is happy
+	 */
+	@Test
+	public void okTest_One() {
+		population.add(happy());
+		
+		List<ConstraintViolation> list = sut.validate(population);
+		
+		assertTrue("There must be not unhappy people in this population", list.isEmpty());
+	}
+
+	/**
+	 * Checks that adding some unhappy people to the happy population will fail validation.
+	 */
+	@Test
+	public void failTest_Some() {
+		population.add(happy(), unhappy(), unhappy(), happy());
+		
+		List<ConstraintViolation> list = sut.validate(population);
+		
+		assertFalse("This population should not be all happy",list.isEmpty());
+		assertEquals(1, list.size());
+		ConstraintViolation violation = list.get(0);
+		assertNull(violation.getCauses());
+		assertEquals(population.people.get(1), violation.getInvalidValue());
+	}
+
+	/**
+	 * Checks that adding some unhappy people to the happy population will fail validation.
+	 */
+	@Test
+	public void failTest_All() {
+		population.add(unhappy());
+		
+		List<ConstraintViolation> list = sut.validate(population);
+		
+		assertFalse("This population should not be all happy",list.isEmpty());
+		assertEquals(1, list.size());
+		ConstraintViolation violation = list.get(0);
+		assertNull(violation.getCauses());
+		assertEquals(population.people.get(0), violation.getInvalidValue());
+	}
+
+
+	/**
+	 * Sample population consisting of people.
+	 * @author anydoby
+	 *
+	 */
+	public static class HappyPopulation
+	{
+		
+		@AssertNull(target="jxpath:.[happy = false()]") 
+		List<Person> people = new ArrayList<NoTargetAccessorTest.Person>();
+		
+		/**
+		 * @return happy people
+		 */
+		public List<Person> getPeople()
+		{
+			return people;
+		}
+		
+		/**
+		 * @param p
+		 */
+		public void add(Person... p) {
+			people.addAll(asList(p));
+		}
+		
+	}
+
+	/**
+	 * @author anydoby
+	 *
+	 */
+	public static class Person
+	{
+		private boolean happy;
+
+		/**
+		 * @return <code>true</code> for happy people
+		 */
+		public boolean isHappy()
+		{
+			return happy;
+		}
+
+		/**
+		 * @return a new happy person
+		 */
+		public static Person happy()
+		{
+			Person person = new Person();
+			person.happy = true;
+			return person;
+		}
+
+		/**
+		 * @return a new unhappy person
+		 */
+		public static Person unhappy()
+		{
+			Person person = new Person();
+			return person;
+		}
+		
+		@Override
+		public String toString()
+		{
+			return isHappy() ? "happy" : "unhappy";
+		}
+	}
+	
+}


### PR DESCRIPTION
In my case I wanted to validate a collection of objects without validating the nested objects, like this:

    @IsInvariant
    @AssertNull(target = "jxpath:.[deferred]")
    public List<Instrument> getSubentities()
    {
        .....
    }

This essentially checks that the subentities collection has no "deferred" instruments (that's from my domain of course). Previously this would throw an unclear exception because the result.targetAccessor is null.