### PR TITLE
Add checking on java.time.* API (Past/Future)

### DIFF
--- a/src/main/java/net/sf/oval/constraint/FutureCheck.java
+++ b/src/main/java/net/sf/oval/constraint/FutureCheck.java
@@ -59,6 +59,44 @@ public class FutureCheck extends AbstractAnnotationCheck<Future> {
         if (valueToValidate instanceof Calendar)
             return ((Calendar) valueToValidate).getTime().getTime() > now;
 
+        // check value against java.time.* API
+        try {
+            Class.forName("java.time.ZoneId");
+            Class.forName("java.time.LocalDate");
+            Class.forName("java.time.LocalTime");
+            Class.forName("java.time.LocalDateTime");
+            Class.forName("java.time.OffsetTime");
+            Class.forName("java.time.OffsetDateTime");
+            Class.forName("java.time.ZonedDateTime");
+
+            // check if the value is a LocalDate
+            if (valueToValidate instanceof java.time.LocalDate)
+                return ((java.time.LocalDate) valueToValidate).atStartOfDay().atZone(java.time.ZoneId.systemDefault()).toInstant().toEpochMilli() > now;
+
+            // check if the value is a LocalTime
+            if (valueToValidate instanceof java.time.LocalTime)
+                return ((java.time.LocalTime) valueToValidate).atDate(java.time.LocalDate.now()).atZone(java.time.ZoneId.systemDefault()).toInstant().toEpochMilli() > now;
+
+            // check if the value is a LocalDateTime
+            if (valueToValidate instanceof java.time.LocalDateTime)
+                return ((java.time.LocalDateTime) valueToValidate).atZone(java.time.ZoneId.systemDefault()).toInstant().toEpochMilli() > now;
+
+            // check if the value is an OffsetTime
+            if (valueToValidate instanceof java.time.OffsetTime)
+                return ((java.time.OffsetTime) valueToValidate).atDate(java.time.LocalDate.now()).toInstant().toEpochMilli() > now;
+
+            // check if the value is an OffsetDateTime
+            if (valueToValidate instanceof java.time.OffsetDateTime)
+                return ((java.time.OffsetDateTime) valueToValidate).toInstant().toEpochMilli() > now;
+
+            // check if the value is an ZonedDateTime
+            if (valueToValidate instanceof java.time.ZonedDateTime)
+                return ((java.time.ZonedDateTime) valueToValidate).toInstant().toEpochMilli() > now;
+
+        } catch (ClassNotFoundException e) {
+            // continue checking
+        }
+
         // see if we can extract a date based on the object's String representation
         final String stringValue = valueToValidate.toString();
         try {

--- a/src/main/java/net/sf/oval/constraint/PastCheck.java
+++ b/src/main/java/net/sf/oval/constraint/PastCheck.java
@@ -59,6 +59,44 @@ public class PastCheck extends AbstractAnnotationCheck<Past> {
         if (valueToValidate instanceof Calendar) // return ((Calendar) value).getTime().before(new Date());
             return ((Calendar) valueToValidate).getTime().getTime() < now;
 
+        // check value against java.time.* API
+        try {
+            Class.forName("java.time.ZoneId");
+            Class.forName("java.time.LocalDate");
+            Class.forName("java.time.LocalTime");
+            Class.forName("java.time.LocalDateTime");
+            Class.forName("java.time.OffsetTime");
+            Class.forName("java.time.OffsetDateTime");
+            Class.forName("java.time.ZonedDateTime");
+
+            // check if the value is a LocalDate
+            if (valueToValidate instanceof java.time.LocalDate)
+                return ((java.time.LocalDate) valueToValidate).atStartOfDay().atZone(java.time.ZoneId.systemDefault()).toInstant().toEpochMilli() < now;
+
+            // check if the value is a LocalTime
+            if (valueToValidate instanceof java.time.LocalTime)
+                return ((java.time.LocalTime) valueToValidate).atDate(java.time.LocalDate.now()).atZone(java.time.ZoneId.systemDefault()).toInstant().toEpochMilli() < now;
+
+            // check if the value is a LocalDateTime
+            if (valueToValidate instanceof java.time.LocalDateTime)
+                return ((java.time.LocalDateTime) valueToValidate).atZone(java.time.ZoneId.systemDefault()).toInstant().toEpochMilli() < now;
+
+            // check if the value is an OffsetTime
+            if (valueToValidate instanceof java.time.OffsetTime)
+                return ((java.time.OffsetTime) valueToValidate).atDate(java.time.LocalDate.now()).toInstant().toEpochMilli() < now;
+
+            // check if the value is an OffsetDateTime
+            if (valueToValidate instanceof java.time.OffsetDateTime)
+                return ((java.time.OffsetDateTime) valueToValidate).toInstant().toEpochMilli() < now;
+
+            // check if the value is an ZonedDateTime
+            if (valueToValidate instanceof java.time.ZonedDateTime)
+                return ((java.time.ZonedDateTime) valueToValidate).toInstant().toEpochMilli() < now;
+
+        } catch (ClassNotFoundException e) {
+            // continue checking
+        }
+
         // see if we can extract a date based on the object's String representation
         final String stringValue = valueToValidate.toString();
         try {


### PR DESCRIPTION
Created to fix #5.

I made some choices about the way types should be considered. If you don't agree on any comparison implementation, please tell me.

By the way, I don't know how to test (TU) wether this will work with JRE5 or not, as there shouldn't be LocalDate and stuff in this JRE version.