### PR TITLE
Bug fix unit tests for XML validator (depends of version XStream)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@ Besides field/property validation OVal implements Programming by Contract featur
 			<groupId>com.thoughtworks.xstream</groupId>
 			<artifactId>xstream</artifactId>
 			<!-- cannot upgrade to 1.4.5-1.4.9 which results in an xstream internal RuntimeException -->
-			<version>1.4.4</version>
+			<version>1.4.3</version>
 			<optional>true</optional>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Hi!
We use oval for our project, thank you!

I found this bug when I tried to run all tests.
I saw that you changed a version of XStream and come back, but with 1.4.4. the error is reproducible.

**Problem:**
java.lang.ArrayIndexOutOfBoundsException: -1
	at com.thoughtworks.xstream.core.util.OrderRetainingMap.entrySet(OrderRetainingMap.java:77)
	at java.util.HashMap.putMapEntries(HashMap.java:511)
	at java.util.HashMap.putAll(HashMap.java:784)
	at com.thoughtworks.xstream.core.util.OrderRetainingMap.<init>(OrderRetainingMap.java:36)
	at com.thoughtworks.xstream.converters.reflection.FieldDictionary.buildMap(FieldDictionary.java:135)
...
	at net.sf.oval.configuration.xml.XMLConfigurer.toXML(XMLConfigurer.java:517)

**How to reproduce?**
- Run all tests. (I make it with IntelliJ IDEA)
OR

- Maven: clean install

**How to fix?**
<dependency>
    <groupId>com.thoughtworks.xstream</groupId>
    <artifactId>xstream</artifactId>
    <version>1.4.3</version>
</dependency>

In result: All tests are green.