### PR TITLE
Fixed test "Connecting failed with exception"

### DIFF
--- a/src/test/java/net/sf/oval/test/constraints/AssertURLTest.java
+++ b/src/test/java/net/sf/oval/test/constraints/AssertURLTest.java
@@ -60,7 +60,7 @@ public class AssertURLTest extends AbstractContraintsTest {
         assertTrue(check.isSatisfied(this, "http://www.google.com", null, validator));
         //assertTrue(check.isSatisfied(this, "https://www.verisign.com/site-map/index.html", null, validator));
         assertFalse(check.isSatisfied(this, "http://127.0.0.1:34343", null, validator));
-        assertTrue(check.isSatisfied(this, "ftp://ftp.debian.org/debian/README.html", null, validator));
+        assertTrue(check.isSatisfied(this, "http://ftp.debian.org/debian/README.html", null, validator));
         assertFalse(check.isSatisfied(this, "ftp://ftp.debian.org/debian/foo.html", null, validator));
 
         check.setPermittedURISchemes(null);

--- a/src/test/java/net/sf/oval/test/constraints/AssertURLTest.java
+++ b/src/test/java/net/sf/oval/test/constraints/AssertURLTest.java
@@ -60,7 +60,7 @@ public class AssertURLTest extends AbstractContraintsTest {
         assertTrue(check.isSatisfied(this, "http://www.google.com", null, validator));
         //assertTrue(check.isSatisfied(this, "https://www.verisign.com/site-map/index.html", null, validator));
         assertFalse(check.isSatisfied(this, "http://127.0.0.1:34343", null, validator));
-        assertTrue(check.isSatisfied(this, "http://ftp.debian.org/debian/README.html", null, validator));
+        assertTrue(check.isSatisfied(this, "ftp://speedtest.tele2.net/512KB.zip", null, validator));
         assertFalse(check.isSatisfied(this, "ftp://ftp.debian.org/debian/foo.html", null, validator));
 
         check.setPermittedURISchemes(null);


### PR DESCRIPTION
Hi! 
After `mvn clean install`, I'm getting a failed test.
```
java.net.ConnectException: Connection refused (Connection refused)
	at java.net.PlainSocketImpl.socketConnect(Native Method)
	at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:350)
	at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:206)
	at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:188)
	at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392)
	at java.net.Socket.connect(Socket.java:589)
	at java.net.Socket.connect(Socket.java:538)
	at sun.net.NetworkClient.doConnect(NetworkClient.java:180)
	at sun.net.www.http.HttpClient.openServer(HttpClient.java:463)
	at sun.net.www.http.HttpClient.openServer(HttpClient.java:558)
	at sun.net.www.http.HttpClient.<init>(HttpClient.java:242)
	at sun.net.www.http.HttpClient.New(HttpClient.java:339)
	at sun.net.www.http.HttpClient.New(HttpClient.java:357)
	at sun.net.www.protocol.http.HttpURLConnection.getNewHttpClient(HttpURLConnection.java:1202)
	at sun.net.www.protocol.http.HttpURLConnection.plainConnect0(HttpURLConnection.java:1138)
	at sun.net.www.protocol.http.HttpURLConnection.plainConnect(HttpURLConnection.java:1032)
	at sun.net.www.protocol.http.HttpURLConnection.connect(HttpURLConnection.java:966)
	at net.sf.oval.constraint.AssertURLCheck.canConnect(AssertURLCheck.java:74)
```

**What is the problem?**

- All public-facing debian.org **FTP services shut down on November 1, 2017.** 
Proof: [Shutting down public FTP services](https://www.debian.org/News/2017/20170425)

**How to fix?**
Use HTTP instead of FTP