### PR TITLE
Read type annotations from interfaces

### DIFF
--- a/src/main/java/net/sf/oval/configuration/annotation/AnnotationsConfigurer.java
+++ b/src/main/java/net/sf/oval/configuration/annotation/AnnotationsConfigurer.java
@@ -220,6 +220,12 @@ public class AnnotationsConfigurer implements Configurer {
 
          initializeGenericTypeChecks(method.getReturnType(), method.getAnnotatedReturnType(), returnValueChecks);
 
+         if (Boolean.TRUE.equals(classCfg.inspectInterfaces)) {
+            for (final Method interfaceMethod : ReflectionUtils.getInterfaceMethods(method, classCfg.includedInterfaces, classCfg.excludedInterfaces)) {
+               initializeGenericTypeChecks(interfaceMethod.getReturnType(), interfaceMethod.getAnnotatedReturnType(), returnValueChecks);
+            }
+         }
+
          /*
           * determine parameter checks
           */

--- a/src/main/java/net/sf/oval/internal/util/ReflectionUtils.java
+++ b/src/main/java/net/sf/oval/internal/util/ReflectionUtils.java
@@ -9,7 +9,8 @@
  *********************************************************************/
 package net.sf.oval.internal.util;
 
-import static net.sf.oval.Validator.*;
+import static net.sf.oval.Validator.getCollectionFactory;
+import static net.sf.oval.Validator.getLocaleProvider;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AccessibleObject;
@@ -209,6 +210,31 @@ public final class ReflectionUtils {
          return null;
 
       return getGetterRecursive(superclazz, propertyName);
+   }
+
+   public static List<Method> getInterfaceMethods(final Method method, final Set<Class<?>> includedInterfaces, final Set<Class<?>> excludedInterfaces) {
+      // static methods cannot be overridden
+      if (isStatic(method)) {
+         return Collections.emptyList();
+      }
+
+      final Set<Class<?>> interfaces = getInterfacesRecursive(method.getDeclaringClass(), includedInterfaces, excludedInterfaces);
+      if (interfaces.isEmpty()) {
+         return Collections.emptyList();
+      }
+
+      final String methodName = method.getName();
+      final Class<?>[] parameterTypes = method.getParameterTypes();
+
+      final List<Method> methods = getCollectionFactory().createList(interfaces.size());
+      for (final Class<?> iface : interfaces) {
+         final Method m = getMethod(iface, methodName, parameterTypes);
+         if (m != null) {
+            methods.add(m);
+         }
+      }
+
+      return methods;
    }
 
    /**

--- a/src/test/java/net/sf/oval/test/ReflectionUtilsTest.java
+++ b/src/test/java/net/sf/oval/test/ReflectionUtilsTest.java
@@ -1,0 +1,76 @@
+package net.sf.oval.test;
+
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.List;
+
+import junit.framework.TestCase;
+import net.sf.oval.internal.util.ReflectionUtils;
+
+/**
+ * @author Gary Madden
+ */
+public class ReflectionUtilsTest extends TestCase {
+   public void testGetInterfaceMethods() throws NoSuchMethodException {
+      List<Method> methods = ReflectionUtils.getInterfaceMethods(Interface.class.getDeclaredMethod("doIt"), Collections.emptySet(), Collections.emptySet());
+      assertTrue(methods.isEmpty());
+
+      methods = ReflectionUtils.getInterfaceMethods(Implementation.class.getDeclaredMethod("doIt"), Collections.emptySet(), Collections.emptySet());
+      assertEquals(Collections.singletonList(Interface.class.getDeclaredMethod("doIt")), methods);
+
+      methods = ReflectionUtils.getInterfaceMethods(Implementation.class.getDeclaredMethod("doIt"),
+              Collections.emptySet(), Collections.singleton(Interface.class));
+      assertTrue(methods.isEmpty());
+
+      methods = ReflectionUtils.getInterfaceMethods(Implementation.class.getDeclaredMethod("doIt"),
+              Collections.singleton(Interface.class), Collections.emptySet());
+      assertEquals(Collections.singletonList(Interface.class.getDeclaredMethod("doIt")), methods);
+
+      methods = ReflectionUtils.getInterfaceMethods(Implementation.class.getDeclaredMethod("doSomethingElse"), Collections.emptySet(), Collections.emptySet());
+      assertTrue(methods.isEmpty());
+
+      methods = ReflectionUtils.getInterfaceMethods(Implementation.class.getDeclaredMethod("doAnotherThing"), Collections.emptySet(), Collections.emptySet());
+      assertTrue(methods.isEmpty());
+
+      methods = ReflectionUtils.getInterfaceMethods(ImplementationChild.class.getDeclaredMethod("doIt"), Collections.emptySet(), Collections.emptySet());
+      assertEquals(Collections.singletonList(Interface.class.getDeclaredMethod("doIt")), methods);
+
+      methods = ReflectionUtils.getInterfaceMethods(ImplementationChild.class.getDeclaredMethod("doIt"),
+              Collections.emptySet(), Collections.singleton(Interface.class));
+      assertTrue(methods.isEmpty());
+
+      methods = ReflectionUtils.getInterfaceMethods(ImplementationChild.class.getDeclaredMethod("doIt"),
+              Collections.singleton(Interface.class), Collections.emptySet());
+      assertEquals(Collections.singletonList(Interface.class.getDeclaredMethod("doIt")), methods);
+
+      methods = ReflectionUtils.getInterfaceMethods(OtherClass.class.getDeclaredMethod("doIt"), Collections.emptySet(), Collections.emptySet());
+      assertTrue(methods.isEmpty());
+   }
+
+   interface Interface {
+      void doIt();
+   }
+
+   static class Implementation implements Interface {
+      @Override
+      public void doIt() {
+      }
+
+      public void doSomethingElse() {
+      }
+
+      static void doAnotherThing() {
+      }
+   }
+
+   static class ImplementationChild extends Implementation {
+      @Override
+      public void doIt() {
+      }
+   }
+
+   static class OtherClass {
+      public void doIt() {
+      }
+   }
+}


### PR DESCRIPTION
Related to issue https://github.com/sebthom/oval/issues/19. This improvement reads the type annotations from a method's interface declaration.